### PR TITLE
Create IIP-51.md

### DIFF
--- a/iips/IIP-51.md
+++ b/iips/IIP-51.md
@@ -1,0 +1,37 @@
+---
+iip: 51
+title: Adjusting Vesting and Season Lengths for Loyalty Airdrop and Gameplay Drops
+status: Proposed
+author: Kieran Warwick
+discussions-to: [https://discord.gg/illuvium](https://discord.com/channels/760344898200666112/1237572602210549810)
+created: 2024-05-08
+updated: N/A
+---
+## IIP-XX: Adjusting Vesting and Season Lengths for Loyalty Airdrop and Gameplay Drops
+
+**Sponsor:** Kieran | Illuvium
+
+### Simple Summary
+This IIP proposes reducing the vesting periods and altering the release structure for the Illuvium Loyalty Airdrop and Gameplay Drops. The adjustments aim to offer a more immediate incentive for participants while ensuring unclaimed rewards are available for future campaigns.
+
+### Abstract
+The proposal introduces two fundamental changes:
+
+#### Loyalty Airdrop:
+- **Reduce the vesting period** from six months to three months.
+- Participants can **unlock 50% of their rewards immediately** but forfeit the remaining 50% if they claim early. Total rewards vest over the next three months.
+- Any unclaimed rewards are returned to the treasury for future campaigns.
+
+#### Gameplay Drops:
+- Implement **shorter one-month seasons** instead of six-month seasons.
+- **Reduce the vesting period** to three months.
+- Participants can **unlock 50% of their rewards immediately** but forfeit the remaining 50% if they claim early. Total rewards vest over the next three months.
+- Any unclaimed rewards are returned to the treasury for future campaigns.
+
+### Overview
+The **Loyalty Airdrop’s vesting period** will now be three months instead of six. Participants can access 50% of their rewards immediately, with the remaining 50% vesting over three months. However, if participants claim their rewards early, they will lose the unvested portion, which will be returned to the treasury to support future campaigns.
+
+**Gameplay Drops** will feature one-month seasons, offering a shorter, more dynamic structure than the previous six-month season approach. The vesting period will be reduced to three months, with participants able to unlock 50% of their rewards immediately. The remaining 50% will vest over the three months. As with the Loyalty Airdrop, claiming early will result in forfeiting unvested rewards, which will be returned to the treasury.
+
+### Rationale
+The **Loyalty Airdrop’s shorter vesting period** allows participants to unlock 50% of their rewards immediately or remain vested for three months to receive the entire amount. Claiming early will result in forfeiting the remaining rewards to ensure ecosystem stability and support future campaigns. Similarly, the one-month seasons for Gameplay Drops encourage regular engagement while following the same vesting structure. Any unclaimed rewards are returned to the treasury for future use. The changes are implemented to address concerns raised by the community during governance discussions.


### PR DESCRIPTION
---
iip: 51
title: Adjusting Vesting and Season Lengths for Loyalty Airdrop and Gameplay Drops
status: Proposed
author: Kieran Warwick
discussions-to: [https://discord.gg/illuvium](https://discord.com/channels/760344898200666112/1237572602210549810)
created: 2024-05-08
updated: N/A
---
## IIP-XX: Adjusting Vesting and Season Lengths for Loyalty Airdrop and Gameplay Drops

**Sponsor:** Kieran | Illuvium

### Simple Summary
This IIP proposes reducing the vesting periods and altering the release structure for the Illuvium Loyalty Airdrop and Gameplay Drops. The adjustments aim to offer a more immediate incentive for participants while ensuring unclaimed rewards are available for future campaigns.

### Abstract
The proposal introduces two fundamental changes:

#### Loyalty Airdrop:
- **Reduce the vesting period** from six months to three months.
- Participants can **unlock 50% of their rewards immediately** but forfeit the remaining 50% if they claim early. Total rewards vest over the next three months.
- Any unclaimed rewards are returned to the treasury for future campaigns.

#### Gameplay Drops:
- Implement **shorter one-month seasons** instead of six-month seasons.
- **Reduce the vesting period** to three months.
- Participants can **unlock 50% of their rewards immediately** but forfeit the remaining 50% if they claim early. Total rewards vest over the next three months.
- Any unclaimed rewards are returned to the treasury for future campaigns.

### Overview
The **Loyalty Airdrop’s vesting period** will now be three months instead of six. Participants can access 50% of their rewards immediately, with the remaining 50% vesting over three months. However, if participants claim their rewards early, they will lose the unvested portion, which will be returned to the treasury to support future campaigns.

**Gameplay Drops** will feature one-month seasons, offering a shorter, more dynamic structure than the previous six-month season approach. The vesting period will be reduced to three months, with participants able to unlock 50% of their rewards immediately. The remaining 50% will vest over the three months. As with the Loyalty Airdrop, claiming early will result in forfeiting unvested rewards, which will be returned to the treasury.

### Rationale
The **Loyalty Airdrop’s shorter vesting period** allows participants to unlock 50% of their rewards immediately or remain vested for three months to receive the entire amount. Claiming early will result in forfeiting the remaining rewards to ensure ecosystem stability and support future campaigns. Similarly, the one-month seasons for Gameplay Drops encourage regular engagement while following the same vesting structure. Any unclaimed rewards are returned to the treasury for future use. The changes are implemented to address concerns raised by the community during governance discussions.